### PR TITLE
Enable development mode and volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - MYSQL_USER=user
       - MYSQL_PASSWORD=password
       - MYSQL_DATABASE=app_db
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
+    volumes:
+      - .:/app
     depends_on:
       - db
 

--- a/run.py
+++ b/run.py
@@ -1,7 +1,9 @@
 from app import create_app
+import os
 
 app = create_app()
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    debug = os.getenv('FLASK_ENV') == 'development' or os.getenv('FLASK_DEBUG') == '1'
+    app.run(host='0.0.0.0', port=5000, debug=debug)


### PR DESCRIPTION
## Summary
- add FLASK_ENV and FLASK_DEBUG variables
- mount current directory into the app container
- start app with debug mode if development env set

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68671c0c54d8832cadfee222dff74b54