### PR TITLE
Import models in app factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ The MySQL server listens on host port `3308`.
 ## Database migrations
 
 Use `Flask-Migrate` to manage schema changes. Set the `FLASK_APP` variable to
-`app:create_app` and run the commands below.
+`app:create_app` and ensure the models module is imported inside the application
+factory (for example `from . import models`). With that in place, run the
+commands below.
 
 ```bash
 # Initialise the migrations folder (run once)

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,9 @@ Para interromper, pressione `Ctrl+C` e execute `docker compose down`.
 ## Rodando as migrações
 
 O controle de versões do banco é feito com o *Flask-Migrate*. Após instalar as
-dependências e definir `FLASK_APP=app:create_app`, execute:
+dependências e definir `FLASK_APP=app:create_app`, garanta que o módulo de
+modelos seja importado na função `create_app` (por exemplo `from . import models`).
+Depois disso, execute:
 
 ```bash
 # primeira execução

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,10 @@ def create_app():
     # init extensions
     CORS(app)
     db.init_app(app)
+
+    # Import models so they are registered with SQLAlchemy before migrations
+    from . import models  # noqa: F401
+
     migrate.init_app(app, db)
 
     # register blueprints


### PR DESCRIPTION
## Summary
- import the models module during app creation
- clarify migrations instructions in the docs (EN/PT)

## Testing
- `python -m py_compile app/__init__.py app/models/product.py app/controllers/home_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_686725121a7c832c8c7ba6bdfb6a0a39