### PR TITLE
Implement product list pagination and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ If running the project without Docker, simply call:
 ```bash
 python seed.py
 ```
+
+## Listing products
+
+The `/products` endpoint supports optional pagination and filtering. Use the
+`page` and `per_page` query parameters to control pagination (defaults are `1`
+and `10`). Filtering by `name`, `min_price` and `max_price` can also be applied
+alongside a free text `search` that checks the product `id` and `name` fields.

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -1,19 +1,55 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
+from sqlalchemy import or_
 from app.models import Product
 
-product_bp = Blueprint('products', __name__, url_prefix='/products')
+product_bp = Blueprint("products", __name__, url_prefix="/products")
 
 
-@product_bp.route('/', methods=['GET'])
+@product_bp.route("/", methods=["GET"])
 def list_products():
-    """Return a list of all products."""
-    products = Product.query.all()
+    """List products with optional pagination and filtering."""
+    page = request.args.get("page", default=1, type=int)
+    per_page = request.args.get("per_page", default=10, type=int)
+
+    search = request.args.get("search")
+    name = request.args.get("name")
+    min_price = request.args.get("min_price", type=float)
+    max_price = request.args.get("max_price", type=float)
+
+    query = Product.query
+
+    if search:
+        like = f"%{search}%"
+        try:
+            search_id = int(search)
+            query = query.filter(or_(Product.name.ilike(like), Product.id == search_id))
+        except ValueError:
+            query = query.filter(Product.name.ilike(like))
+
+    if name:
+        query = query.filter(Product.name.ilike(f"%{name}%"))
+
+    if min_price is not None:
+        query = query.filter(Product.price >= min_price)
+
+    if max_price is not None:
+        query = query.filter(Product.price <= max_price)
+
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+
     result = [
         {
             "id": product.id,
             "name": product.name,
             "price": float(product.price),
         }
-        for product in products
+        for product in pagination.items
     ]
-    return jsonify(products=result)
+
+    return jsonify(
+        items=result,
+        total=pagination.total,
+        page=pagination.page,
+        pages=pagination.pages,
+        per_page=pagination.per_page,
+    )


### PR DESCRIPTION
## Summary
- add pagination, search and filters to `list_products`
- document query parameters in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686732f5e424832c9dfce01609ec52aa