### PR TITLE
Add product retrieval by id endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ The `/products` endpoint supports optional pagination and filtering. Use the
 `page` and `per_page` query parameters to control pagination (defaults are `1`
 and `10`). Filtering by `name`, `min_price` and `max_price` can also be applied
 alongside a free text `search` that checks the product `id` and `name` fields.
+
+## Retrieving a single product
+
+Use `GET /products/<id>` to fetch the details for a specific product. The
+response body will contain the product `id`, `name` and `price`.

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, abort
 from sqlalchemy import or_
 from app.models import Product
 
@@ -53,3 +53,13 @@ def list_products():
         pages=pagination.pages,
         per_page=pagination.per_page,
     )
+
+
+@product_bp.route("/<int:product_id>", methods=["GET"])
+def get_product(product_id):
+    """Retrieve a single product by its ID."""
+    product = Product.query.get(product_id)
+    if product is None:
+        abort(404, description="Product not found")
+
+    return jsonify(id=product.id, name=product.name, price=float(product.price))


### PR DESCRIPTION
## Summary
- allow fetching a product by id using `/products/<id>`
- document the new endpoint in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686734966be0832c87ca75b4a5a17e66