### PR TITLE
Add product creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ alongside a free text `search` that checks the product `id` and `name` fields.
 
 Use `GET /products/<id>` to fetch the details for a specific product. The
 response body will contain the product `id`, `name` and `price`.
+
+## Creating a product
+
+Send a JSON payload to `POST /products` with the fields `name` and `price`:
+
+```bash
+curl -X POST http://localhost:5000/products \
+  -H "Content-Type: application/json" \
+  -d '{"name": "New Shirt", "price": 99.90}'
+```
+
+The response will include the created product with its generated `id`.

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify, request, abort
 from sqlalchemy import or_
+from app import db
 from app.models import Product
 
 product_bp = Blueprint("products", __name__, url_prefix="/products")
@@ -52,6 +53,27 @@ def list_products():
         page=pagination.page,
         pages=pagination.pages,
         per_page=pagination.per_page,
+    )
+
+
+@product_bp.route("/", methods=["POST"])
+def create_product():
+    """Create a new product."""
+    data = request.get_json() or {}
+
+    name = data.get("name")
+    price = data.get("price")
+
+    if name is None or price is None:
+        abort(400, description="'name' and 'price' are required fields")
+
+    product = Product(name=name, price=price)
+    db.session.add(product)
+    db.session.commit()
+
+    return (
+        jsonify(id=product.id, name=product.name, price=float(product.price)),
+        201,
     )
 
 


### PR DESCRIPTION
## Summary
- allow adding a new product via POST `/products`
- document how to create a product via the REST API

## Testing
- `python -m py_compile app/controllers/product_controller.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686735dfc374832c90e0b8a753ea263f