### PR TITLE
Add Swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ phpMyAdmin will be accessible at `http://localhost:8080/`.
 
 The MySQL server listens on host port `3308`.
 
+## API Documentation
+
+Interactive Swagger documentation is available once the containers are
+running. Access `http://localhost:5000/apidocs/` in your browser to explore
+the endpoints and their schemas.
+
 ## Database migrations
 
 Use `Flask-Migrate` to manage schema changes. Set the `FLASK_APP` variable to

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,11 @@ Este projeto fornece uma API REST utilizando Flask e MySQL. A maneira mais simpl
    O phpMyAdmin poderá ser acessado em `http://localhost:8080/`.
    O MySQL escutará na porta `3308` do hospedeiro.
 
+## Documentação da API
+
+Após subir os contêineres, acesse `http://localhost:5000/apidocs/` para
+visualizar uma documentação interativa gerada pelo Swagger.
+
 Para interromper, pressione `Ctrl+C` e execute `docker compose down`.
 
 ## Executando sem Docker (opcional)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,11 +2,27 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 from flask_migrate import Migrate
+from flasgger import Swagger
 
 # instantiate extensions
 
 db = SQLAlchemy()
 migrate = Migrate()
+swagger = Swagger()
+swagger_template = {
+    "components": {
+        "schemas": {
+            "Product": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"},
+                    "price": {"type": "number"},
+                },
+            }
+        }
+    }
+}
 
 
 def create_app():
@@ -17,6 +33,12 @@ def create_app():
     # init extensions
     CORS(app)
     db.init_app(app)
+    app.config["SWAGGER"] = {
+        "title": "Flask REST API",
+        "uiversion": 3,
+        "openapi": "3.0.2",
+    }
+    swagger.init_app(app, template=swagger_template)
 
     # Import models so they are registered with SQLAlchemy before migrations
     from . import models  # noqa: F401

--- a/app/controllers/home_controller.py
+++ b/app/controllers/home_controller.py
@@ -5,5 +5,16 @@ home_bp = Blueprint('home', __name__)
 
 @home_bp.route('/')
 def index():
-    """Return a simple greeting."""
+    """Return a simple greeting.
+    ---
+    responses:
+      200:
+        description: API status message
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+              example: Hello World
+    """
     return jsonify(message="Hello World")

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -8,7 +8,60 @@ product_bp = Blueprint("products", __name__, url_prefix="/products")
 
 @product_bp.route("/", methods=["GET"])
 def list_products():
-    """List products with optional pagination and filtering."""
+    """List products with optional pagination and filtering.
+    ---
+    parameters:
+      - name: page
+        in: query
+        type: integer
+        required: false
+        description: Page number
+        default: 1
+      - name: per_page
+        in: query
+        type: integer
+        required: false
+        description: Items per page
+        default: 10
+      - name: search
+        in: query
+        type: string
+        required: false
+        description: Search by id or name
+      - name: name
+        in: query
+        type: string
+        required: false
+        description: Filter by product name
+      - name: min_price
+        in: query
+        type: number
+        required: false
+        description: Minimum price
+      - name: max_price
+        in: query
+        type: number
+        required: false
+        description: Maximum price
+    responses:
+      200:
+        description: Paginated list of products
+        schema:
+          type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Product'
+            total:
+              type: integer
+            page:
+              type: integer
+            pages:
+              type: integer
+            per_page:
+              type: integer
+    """
     page = request.args.get("page", default=1, type=int)
     per_page = request.args.get("per_page", default=10, type=int)
 
@@ -58,7 +111,22 @@ def list_products():
 
 @product_bp.route("/", methods=["POST"])
 def create_product():
-    """Create a new product."""
+    """Create a new product.
+    ---
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Product'
+    responses:
+      201:
+        description: Product created
+        schema:
+          $ref: '#/components/schemas/Product'
+      400:
+        description: Validation error
+    """
     data = request.get_json() or {}
 
     name = data.get("name")
@@ -79,7 +147,22 @@ def create_product():
 
 @product_bp.route("/<int:product_id>", methods=["GET"])
 def get_product(product_id):
-    """Retrieve a single product by its ID."""
+    """Retrieve a single product by its ID.
+    ---
+    parameters:
+      - name: product_id
+        in: path
+        type: integer
+        required: true
+        description: Identifier of the product
+    responses:
+      200:
+        description: Product details
+        schema:
+          $ref: '#/components/schemas/Product'
+      404:
+        description: Product not found
+    """
     product = Product.query.get(product_id)
     if product is None:
         abort(404, description="Product not found")
@@ -89,7 +172,28 @@ def get_product(product_id):
 
 @product_bp.route("/<int:product_id>", methods=["PUT"])
 def update_product(product_id):
-    """Update an existing product."""
+    """Update an existing product.
+    ---
+    parameters:
+      - name: product_id
+        in: path
+        type: integer
+        required: true
+        description: Identifier of the product
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Product'
+    responses:
+      200:
+        description: Updated product
+        schema:
+          $ref: '#/components/schemas/Product'
+      404:
+        description: Product not found
+    """
     product = Product.query.get(product_id)
     if product is None:
         abort(404, description="Product not found")
@@ -112,7 +216,20 @@ def update_product(product_id):
 
 @product_bp.route("/<int:product_id>", methods=["DELETE"])
 def delete_product(product_id):
-    """Delete a product by its ID."""
+    """Delete a product by its ID.
+    ---
+    parameters:
+      - name: product_id
+        in: path
+        type: integer
+        required: true
+        description: Identifier of the product
+    responses:
+      204:
+        description: Product deleted
+      404:
+        description: Product not found
+    """
     product = Product.query.get(product_id)
     if product is None:
         abort(404, description="Product not found")


### PR DESCRIPTION
## Summary
- integrate Flasgger with Swagger UI
- document API endpoints with YAML docstrings
- expose interactive docs on `/apidocs/`
- mention docs URL in both READMEs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68673c6ee3fc832cb86147e777f8a055