### PR TITLE
Fix docstrings for OpenAPI3

### DIFF
--- a/app/controllers/home_controller.py
+++ b/app/controllers/home_controller.py
@@ -10,11 +10,13 @@ def index():
     responses:
       200:
         description: API status message
-        schema:
-          type: object
-          properties:
-            message:
-              type: string
-              example: Hello World
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Hello World
     """
     return jsonify(message="Hello World")

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -46,21 +46,23 @@ def list_products():
     responses:
       200:
         description: Paginated list of products
-        schema:
-          type: object
-          properties:
-            items:
-              type: array
-              items:
-                $ref: '#/components/schemas/Product'
-            total:
-              type: integer
-            page:
-              type: integer
-            pages:
-              type: integer
-            per_page:
-              type: integer
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Product'
+                total:
+                  type: integer
+                page:
+                  type: integer
+                pages:
+                  type: integer
+                per_page:
+                  type: integer
     """
     page = request.args.get("page", default=1, type=int)
     per_page = request.args.get("per_page", default=10, type=int)
@@ -122,8 +124,10 @@ def create_product():
     responses:
       201:
         description: Product created
-        schema:
-          $ref: '#/components/schemas/Product'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
       400:
         description: Validation error
     """
@@ -158,8 +162,10 @@ def get_product(product_id):
     responses:
       200:
         description: Product details
-        schema:
-          $ref: '#/components/schemas/Product'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
       404:
         description: Product not found
     """
@@ -189,8 +195,10 @@ def update_product(product_id):
     responses:
       200:
         description: Updated product
-        schema:
-          $ref: '#/components/schemas/Product'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
       404:
         description: Product not found
     """


### PR DESCRIPTION
## Summary
- format `home_controller` response docs for OpenAPI 3
- update `product_controller` docstrings to use OpenAPI 3 response blocks

## Testing
- `python -m py_compile app/controllers/home_controller.py app/controllers/product_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_68673eda79e4832cb5e7167b4d1764d4